### PR TITLE
uses default export if require() returns an object

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports.pitch = function(remainingRequest) {
 		'		if(!component) {',
 		'			require.ensure([], function() {',
 		'				component = require(' + loaderUtils.stringifyRequest(this, moduleRequest) + ');',
-		'				if (typeof component === "object") component = component.default;',
+		'				if (component && component.default) component = component.default;',
 		'				if(callback) callback(component);',
 		'			}' + (query.name ? ', ' + JSON.stringify(query.name) : '') + ');',
 		'		} else if(callback) callback(component);',

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ module.exports.pitch = function(remainingRequest) {
 		'		if(!component) {',
 		'			require.ensure([], function() {',
 		'				component = require(' + loaderUtils.stringifyRequest(this, moduleRequest) + ');',
+		'				if (typeof component === "object") component = component.default;',
 		'				if(callback) callback(component);',
 		'			}' + (query.name ? ', ' + JSON.stringify(query.name) : '') + ');',
 		'		} else if(callback) callback(component);',


### PR DESCRIPTION
An example of when this happens:

``` js
export class Foo extends React.Component {};
export default decorator(Foo);
```

It just checks to see if the export is an object, and uses `that.default` instead of `that`. There's no compatibility break (previously would throw an error).
